### PR TITLE
Add static asset path variables to viewer.html

### DIFF
--- a/build/generic/build/pdf.js
+++ b/build/generic/build/pdf.js
@@ -29,7 +29,7 @@ factory((root.pdfjsDistBuildPdf = {}));
   'use strict';
 
 var pdfjsVersion = '1.6.236';
-var pdfjsBuild = '2ca270b';
+var pdfjsBuild = '21543f4';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/generic/build/pdf.js
+++ b/build/generic/build/pdf.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdf = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.214';
-var pdfjsBuild = '1c45e8f';
+var pdfjsVersion = '1.6.215';
+var pdfjsBuild = '43c9aea';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?
@@ -10111,6 +10111,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
  */
 var PDFWorker = (function PDFWorkerClosure() {
   var nextFakeWorkerId = 0;
+  var workerSrc = window.workerPath;
 
   function getWorkerSrc() {
     if (typeof workerSrc !== 'undefined') {

--- a/build/generic/build/pdf.js
+++ b/build/generic/build/pdf.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdf = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.217';
-var pdfjsBuild = '42f1df5';
+var pdfjsVersion = '1.6.236';
+var pdfjsBuild = '2ca270b';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/generic/build/pdf.worker.js
+++ b/build/generic/build/pdf.worker.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.214';
-var pdfjsBuild = '1c45e8f';
+var pdfjsVersion = '1.6.215';
+var pdfjsBuild = '43c9aea';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/generic/build/pdf.worker.js
+++ b/build/generic/build/pdf.worker.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.217';
-var pdfjsBuild = '42f1df5';
+var pdfjsVersion = '1.6.236';
+var pdfjsBuild = '2ca270b';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/generic/build/pdf.worker.js
+++ b/build/generic/build/pdf.worker.js
@@ -29,7 +29,7 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   'use strict';
 
 var pdfjsVersion = '1.6.236';
-var pdfjsBuild = '2ca270b';
+var pdfjsBuild = '21543f4';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -26,13 +26,12 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="<?= $assetPath ?>/viewer.css">
+<link rel="stylesheet" href="<?= $assetPath ?>/viewer.css"> 
 
-    <script>
-       window.workerPath = <?= $workerPath ?>;
-    </script>
-    <script src="<?= $scripts[0] ?>"></script>
-    <script src="<?= $assetPath ?>/compatibility.js"></script>
+<script>window.workerPath = <?= $workerPath ?>;</script> 
+<script src="<?= $scripts[0] ?>"></script> 
+<script src="<?= $assetPath ?>/compatibility.js"></script> 
+
     <title>PDF.js viewer</title>
 
 
@@ -42,12 +41,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
-<script src="<?= $assetPath ?>/l10n.js"></script>
+<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties"> 
+<script src="<?= $assetPath ?>/l10n.js"></script> 
 
 
 
-    <script src="<?= $assetPath ?>/viewer.js"></script>
+<script src="<?= $assetPath ?>/viewer.js"></script> 
 
 
   </head>

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -26,23 +26,31 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="stylesheet" href="<?= $assetPath ?>/viewer.css">
+
+    <script>
+       window.workerPath = <?= $workerPath ?>;
+    </script>
+    <script src="<?= $scripts[0] ?>"></script>
+    <script src="<?= $assetPath ?>/compatibility.js"></script>
+    <!-- <script src="<?= $assetPath ?>/viewer.js"></script>   
     <title>PDF.js viewer</title>
 
 
-    <link rel="stylesheet" href="viewer.css">
 
-    <script src="compatibility.js"></script>
+
 
 
 
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="l10n.js"></script>
-<script src="../build/pdf.js"></script>
+<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
+<script src="<?= $assetPath ?>/l10n.js"></script>
+<!-- <script src="../build/pdf.js"></script> -->
 
 
 
-    <script src="viewer.js"></script>
+    <script src="<?= $assetPath ?>/viewer.js"></script>
+
 
   </head>
 

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -33,7 +33,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     </script>
     <script src="<?= $scripts[0] ?>"></script>
     <script src="<?= $assetPath ?>/compatibility.js"></script>
-    <!-- <script src="<?= $assetPath ?>/viewer.js"></script>   
     <title>PDF.js viewer</title>
 
 
@@ -45,7 +44,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
 <script src="<?= $assetPath ?>/l10n.js"></script>
-<!-- <script src="../build/pdf.js"></script> -->
 
 
 

--- a/build/pdf.js
+++ b/build/pdf.js
@@ -29,7 +29,7 @@ factory((root.pdfjsDistBuildPdf = {}));
   'use strict';
 
 var pdfjsVersion = '1.6.236';
-var pdfjsBuild = '2ca270b';
+var pdfjsBuild = '21543f4';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/pdf.js
+++ b/build/pdf.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdf = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.214';
-var pdfjsBuild = '1c45e8f';
+var pdfjsVersion = '1.6.215';
+var pdfjsBuild = '43c9aea';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?
@@ -10131,6 +10131,7 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
  */
 var PDFWorker = (function PDFWorkerClosure() {
   var nextFakeWorkerId = 0;
+  var workerSrc = window.workerPath;
 
   function getWorkerSrc() {
     if (typeof workerSrc !== 'undefined') {

--- a/build/pdf.js
+++ b/build/pdf.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdf = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.217';
-var pdfjsBuild = '42f1df5';
+var pdfjsVersion = '1.6.236';
+var pdfjsBuild = '2ca270b';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/pdf.worker.js
+++ b/build/pdf.worker.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.214';
-var pdfjsBuild = '1c45e8f';
+var pdfjsVersion = '1.6.215';
+var pdfjsBuild = '43c9aea';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/pdf.worker.js
+++ b/build/pdf.worker.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.6.217';
-var pdfjsBuild = '42f1df5';
+var pdfjsVersion = '1.6.236';
+var pdfjsBuild = '2ca270b';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/pdf.worker.js
+++ b/build/pdf.worker.js
@@ -29,7 +29,7 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   'use strict';
 
 var pdfjsVersion = '1.6.236';
-var pdfjsBuild = '2ca270b';
+var pdfjsBuild = '21543f4';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.214",
-  "build": 214,
-  "commit": "1c45e8f"
+  "version": "1.6.215",
+  "build": 215,
+  "commit": "43c9aea"
 }

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
   "version": "1.6.236",
   "build": 236,
-  "commit": "2ca270b"
+  "commit": "21543f4"
 }

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.217",
-  "build": 217,
-  "commit": "42f1df5"
+  "version": "1.6.236",
+  "build": 236,
+  "commit": "2ca270b"
 }

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1025,6 +1025,9 @@ var PDFPageProxy = (function PDFPageProxyClosure() {
  */
 var PDFWorker = (function PDFWorkerClosure() {
   var nextFakeWorkerId = 0;
+//#if GENERIC
+//var workerSrc = window.workerPath;
+//#endif
 
   function getWorkerSrc() {
     if (typeof workerSrc !== 'undefined') {

--- a/web/viewer-snippet-minified.html
+++ b/web/viewer-snippet-minified.html
@@ -1,3 +1,3 @@
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="pdf.viewer.js"></script>
+<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
+<script src="<?= $assetPath ?>/pdf.viewer.js"></script>

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,4 +1,4 @@
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="l10n.js"></script>
-<script src="../build/pdf.js"></script>
+<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
+<script src="<?= $assetPath ?>/l10n.js"></script>
+<!-- <script src="../build/pdf.js"></script> -->

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,3 +1,3 @@
 <!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
-<script src="<?= $assetPath ?>/l10n.js"></script>
+<!--#expand <link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties"> -->
+<!--#expand <script src="<?= $assetPath ?>/l10n.js"></script> -->

--- a/web/viewer-snippet.html
+++ b/web/viewer-snippet.html
@@ -1,4 +1,3 @@
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties">
 <script src="<?= $assetPath ?>/l10n.js"></script>
-<!-- <script src="../build/pdf.js"></script> -->

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -29,6 +29,14 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 <!--#if GENERIC-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="stylesheet" href="<?= $assetPath ?>/viewer.css">
+
+    <script>
+       window.workerPath = <?= $workerPath ?>;
+    </script>
+    <script src="<?= $scripts[0] ?>"></script>
+    <script src="<?= $assetPath ?>/compatibility.js"></script>
+    <!-- <script src="<?= $assetPath ?>/viewer.js"></script> -->
 <!--#endif-->
     <title>PDF.js viewer</title>
 
@@ -39,12 +47,15 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#include viewer-snippet-chrome-extension.html-->
 <!--#endif-->
 
+<!--#if !GENERIC-->
     <link rel="stylesheet" href="viewer.css">
+<!--#endif-->
+
 <!--#if !PRODUCTION-->
     <link rel="resource" type="application/l10n" href="locale/locale.properties">
 <!--#endif-->
 
-<!--#if !(FIREFOX || MOZCENTRAL || CHROME || MINIFIED)-->
+<!--#if !GENERIC && !(FIREFOX || MOZCENTRAL || CHROME || MINIFIED)-->
     <script src="compatibility.js"></script>
 <!--#endif-->
 
@@ -64,9 +75,13 @@ See https://github.com/adobe-type-tools/cmap-resources
     <script src="default_preferences.js"></script>
 <!--#endif-->
 
-<!--#if !MINIFIED -->
-    <script src="viewer.js"></script>
+<!--#if GENERIC-->
+    <script src="<?= $assetPath ?>/viewer.js"></script>
 <!--#else-->
+    <script src="viewer.js"></script>
+<!--#endif-->
+
+<!--#if MINIFIED-->
 <!--#include viewer-snippet-minified.html-->
 <!--#endif-->
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -36,7 +36,6 @@ See https://github.com/adobe-type-tools/cmap-resources
     </script>
     <script src="<?= $scripts[0] ?>"></script>
     <script src="<?= $assetPath ?>/compatibility.js"></script>
-    <!-- <script src="<?= $assetPath ?>/viewer.js"></script> -->
 <!--#endif-->
     <title>PDF.js viewer</title>
 

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -29,13 +29,12 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 <!--#if GENERIC-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="<?= $assetPath ?>/viewer.css">
+<!--#expand <link rel="stylesheet" href="<?= $assetPath ?>/viewer.css"> -->
 
-    <script>
-       window.workerPath = <?= $workerPath ?>;
-    </script>
-    <script src="<?= $scripts[0] ?>"></script>
-    <script src="<?= $assetPath ?>/compatibility.js"></script>
+<!--#expand <script>window.workerPath = <?= $workerPath ?>;</script> -->
+<!--#expand <script src="<?= $scripts[0] ?>"></script> -->
+<!--#expand <script src="<?= $assetPath ?>/compatibility.js"></script> -->
+
 <!--#endif-->
     <title>PDF.js viewer</title>
 
@@ -75,7 +74,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <!--#endif-->
 
 <!--#if GENERIC-->
-    <script src="<?= $assetPath ?>/viewer.js"></script>
+<!--#expand <script src="<?= $assetPath ?>/viewer.js"></script> -->
 <!--#else-->
     <script src="viewer.js"></script>
 <!--#endif-->


### PR DESCRIPTION
This adds the `assetPath` and `workerPath` template variables, which
will be provided by our framework.

The `workerPath` is necessary because PDF.js needs a static script path
to start a WebWorker, so we declare a global `workerPath` variable which
will be used when starting the web worker.