### PR TITLE
Pdfjs: Add ci

### DIFF
--- a/test/exec/continuous-integration.sh
+++ b/test/exec/continuous-integration.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+npm install
+
+# Setup the virtual frame buffer and export the DISPLAY env variable
+Xvfb :1 -screen 5 1024x768x8 &
+# Grab the PID of Xvfb so we can kill it after the unit tests are done
+XVFB_PID=$!
+export DISPLAY=:1.5
+
+# Unit Tests
+./node_modules/gulp/bin/gulp.js unittest
+kill $XVFB_PID
+
+# Lint
+./node_modules/gulp/bin/gulp.js lint

--- a/test/resources/browser_manifests/browser_manifest.json
+++ b/test/resources/browser_manifests/browser_manifest.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Chrome",
+    "path": "/usr/bin/google-chrome"
+  },
+  {
+     "name": "Firefox",
+     "path": "/usr/bin/firefox"
+  }
+]


### PR DESCRIPTION
This adds a continuous-integration script that will be used by cimpler to run the test suite for pdf.js. It also adds a browser_manifest.json that declares the browsers to be tested and the path to the binaries.

CC @danielj41 @danielbeardsley 