### PR TITLE
Pdfjs: Add changes to use Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/ttx/fonttools-code"]
 	path = test/ttx/fonttools-code
-	url = git@github.com:fonttools/fonttools.git
+	url = https://github.com/behdad/fonttools.git


### PR DESCRIPTION
~~This adds a continuous-integration script that will be used by cimpler to run the test suite for pdf.js. It also adds a browser_manifest.json that declares the browsers to be tested and the path to the binaries.~~

We decided to use Travis CI so the only change that's needed is to the url for the fonttools submodule.

CC @danielj41 @danielbeardsley