### PR TITLE
Minor changes for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Since we use an API key for Travis CI we need to use the https url, and since
+# we use the ssh url privately we need to handle git submodules ourselves
+git:
+   submodules: false
+   before_install:
+     - git config submodule.test/ttx/fonttools-code.url https://github.com/behdad/fonttools.git
+     - git submodule update --init --recursive
 language: node_js
 node_js:
   - node


### PR DESCRIPTION
In the pull here: https://github.com/iFixit/pdf.js/pull/14 we change the url from the ssh version to https so Travis CI would work. However in our private ci runs we verify that there are _no_ https git submodule urls. This reverts the change in the pull above and adds a change to the travis.yml file that will convert the url from ssh to https.