### PR TITLE
Remove trailing slash from CdnUrl

### DIFF
--- a/build/generic/web/viewer.js
+++ b/build/generic/web/viewer.js
@@ -7597,7 +7597,10 @@ var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 function configure(PDFJS) {
   PDFJS.imageResourcesPath = './images/';
   PDFJS.workerSrc = '../build/pdf.worker.js';
-  PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps/') ?>';
+
+  <?# CdnUrl cannot have a trailing slash but cMapUrl must ?>
+  PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps') . '/'?>';
+
   PDFJS.cMapPacked = true;
 }
 

--- a/build/viewer.js
+++ b/build/viewer.js
@@ -7597,7 +7597,10 @@ var DISABLE_AUTO_FETCH_LOADING_BAR_TIMEOUT = 5000;
 function configure(PDFJS) {
   PDFJS.imageResourcesPath = './images/';
   PDFJS.workerSrc = '../build/pdf.worker.js';
-  PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps/') ?>';
+
+  <?# CdnUrl cannot have a trailing slash but cMapUrl must ?>
+  PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps') . "/" ?>';
+
   PDFJS.cMapPacked = true;
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -113,7 +113,7 @@ function configure(PDFJS) {
   PDFJS.cMapPacked = true;
   PDFJS.workerSrc = '../src/worker_loader.js';
 //#else
-//PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps/') ?>';
+//PDFJS.cMapUrl = '<?= pdfjsPath('web/cmaps') . '/' ?>';
 //PDFJS.cMapPacked = true;
 //#endif
 }


### PR DESCRIPTION
This pull removes the trailing slash from the one place we construct a CDNUrl as a directory rather than a file.

cr_req 1
qa_req 0

CC @sterlinghirsh 