### PR TITLE
Use a list of scripts to add script tags to page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
      - git submodule update --init --recursive
 language: node_js
 node_js:
-  - node
+  - 10
 cache:
   directories:
     - node_modules

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -30,9 +30,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 <link rel="stylesheet" href="<?= $viewerCSS ?>"> 
 
 <script>window.workerPath = <?= $workerPath ?>;</script> 
-<script src="<?= $runtimeUri ?>"></script>
-<script src="<?= $commonsUri ?>"></script>
-<script src="<?= $pdfjsScript ?>"></script> 
+<? foreach ($scripts as $script): ?>
+<script src="<?= $script ?>"></script>
+<? endforeach ?>
 <script src="<?= $assetPath ?>/compatibility.js"></script> 
 
     <title>PDF.js viewer</title>

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -30,7 +30,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <link rel="stylesheet" href="<?= $viewerCSS ?>"> 
 
 <script>window.workerPath = <?= $workerPath ?>;</script> 
-<? foreach ($scripts as $script): ?>
+<? foreach ($pdfViewerScripts as $script): ?>
 <script src="<?= $script ?>"></script>
 <? endforeach ?>
 <script src="<?= $assetPath ?>/compatibility.js"></script> 


### PR DESCRIPTION
This avoids the need to change the `pdf.js` project every time we want to add another script to this page.

QA
---
We'll QA this as part of the pull that uses it.
qa_req 0