### PR TITLE
Add polyfills for pdfjs

### DIFF
--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -29,6 +29,8 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <link rel="stylesheet" href="<?= $viewerCSS ?>"> 
 
+<script defer src="//cdn.polyfill.io/v3/polyfill.min.js?features=default,Object.entries,Number.isInteger,IntersectionObserver,NodeList.prototype.forEach,WeakSet,WeakMap,fetch,Array.prototype.flatMap"></script>
+
 <script>window.workerPath = <?= $workerPath ?>;</script> 
 <? foreach ($pdfViewerScripts as $script): ?> 
 <script src="<?= $script ?>"></script> 

--- a/build/generic/web/viewer.html
+++ b/build/generic/web/viewer.html
@@ -33,9 +33,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <script>window.workerPath = <?= $workerPath ?>;</script> 
 <? foreach ($pdfViewerScripts as $script): ?> 
-<script src="<?= $script ?>"></script> 
+<script defer src="<?= $script ?>"></script> 
 <? endforeach ?> 
-<script src="<?= $assetPath ?>/compatibility.js"></script> 
+<script defer src="<?= $assetPath ?>/compatibility.js"></script> 
 
     <title>PDF.js viewer</title>
 
@@ -49,11 +49,11 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="<?= $assetPath ?>/locale/locale.properties"> 
-<script src="<?= $assetPath ?>/l10n.js"></script> 
+<script defer src="<?= $assetPath ?>/l10n.js"></script> 
 
 
 
-<script src="<?= $viewerScript ?>"></script> 
+<script defer src="<?= $viewerScript ?>"></script> 
 
 
   </head>


### PR DESCRIPTION
We were not including our Polyfill.io polyfills for the pdfjs template. Lets add them.

While we're here, we can also include the `defer` property to the script tags being included.

Ref: https://github.com/iFixit/ifixit/issues/33275

CC @andyg0808 